### PR TITLE
Updates Per Roger's Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,7 @@
 
 ### Basic Usage
 
-```hcl
-module "ms365_hass_calendar" {
-  source  = "codycodes/ms365-hass/azuread"
-  version = "~>1.0"
-
-  selected_service = "calendar"
-}
-```
-
-Please see the [examples](./examples) folder for more configurations, or take a look at the [variables](./variables.tf) page to see the inputs supported by this module.
+Please see the [examples](./examples) folder for a configuration example (that calls this module), take a look at the a fancy rendering of the inputs [on the module's Terraform Registry page](https://registry.terraform.io/modules/codycodes/ms365-hass/azuread/latest?tab=inputs) or peep the [variables](./variables.tf) page directly to see the inputs supported by this module.
 
 ### Setup
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,10 +38,10 @@ variable "rotation_window_days" {
   default     = 365
 }
 
-variable "custom_permissions" {
-  type        = set(string)
-  description = "Custom permissions to use instead of local.permissions"
-  default     = null
+variable "preassign_permissions" {
+  type        = bool
+  description = "Determines whether permissions for the app should be pre-assigned (greatest privilege) or assigned at auth-time (least privilege)"
+  default     = false
 }
 
 variable "owners" {


### PR DESCRIPTION
Two main changes:
1. Improves the security and usage of the module by giving the user the ability to select whether they want to have permissions assigned at provision time by configuring `var.preassign_permissions`. By default this is set to `false` (turned off), as permissions can be granted directly at auth-time.
2. Removes "Basic Usage" as it could be confusing. Also, this information is present automagically on the module's Public Registry's [page](https://registry.terraform.io/modules/codycodes/ms365-hass/azuread/latest?tab=inputs)
